### PR TITLE
Improve SC2ActorResource to include list of movies per actor

### DIFF
--- a/api/code/apiserver.py
+++ b/api/code/apiserver.py
@@ -114,7 +114,7 @@ class SC3ShortActorResource:
             elif fname:
                 query = basequery + ' WHERE a.fname = \'' + str(fname) + '\''
 
-            query += 'group BY a.idactors'
+            query += 'group BY a.idactors, a.fname, a.mname, a.lname'
 
             rows = execute(query)
             resp.body = json.dumps(rows)

--- a/api/code/apiserver.py
+++ b/api/code/apiserver.py
@@ -102,6 +102,8 @@ class SC2ActorResource:
             unique_movies = list({movie['id']: movie for movie in movies}.values())
             if len(rows) > 0:
                 result = {
+                    # TODO: we assume here that the query will result in a unique idactors, which may not always be
+                    # the case for queries by name
                     'first_name': rows[0][1],
                     'last_name': rows[0][2],
                     'gender': rows[0][3],

--- a/api/code/apiserver.py
+++ b/api/code/apiserver.py
@@ -1,4 +1,6 @@
 import json
+import os
+
 import psycopg2
 
 database_options = ['postgres', 'redis', 'couchdb']
@@ -7,7 +9,11 @@ selected_database_option = database_options[0]
 
 conn = None
 try:
-    conn = psycopg2.connect("dbname='postgres' user='postgres' host='localhost' password='Koekje123'")
+    dbname = os.getenv('DBNAME', 'postgres')
+    user = os.getenv('DBUSER', 'postgres')
+    host = os.getenv('DBHOST', 'localhost')
+    password = os.getenv('DBPASSWORD', 'Koekje123')
+    conn = psycopg2.connect(dbname=dbname, user=user, host=host, password=password)
 except:
     print("I am unable to connect to the database, exitting")
     exit(-1)


### PR DESCRIPTION
Full list of changes:
- Allow postgres configuration to be set as environment variables.
- Add list of movies to SC2ActorResource. This requires a bit of extra code to deduplicate movies by actor. Also fixes bug where actor would be returned multiple times for every role they played, by deduplicating actors.
- Add a.fname, a.mname, a.lname to `group BY` clause in query for SC3ShortActorResource. This fixes the query to always work, even when primary keys have not been set manually.